### PR TITLE
Add required library for Mingw cross-compilation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -52,7 +52,7 @@ Com_DIR = $(EPICS_BASE_LIB)
 gdd_DIR = $(EPICS_BASE_LIB)
 
 SYS_PROD_LIBS_solaris := nsl
-SYS_PROD_LIBS_WIN32 := ws2_32 advapi32 user32
+SYS_PROD_LIBS_WIN32 := ws2_32 advapi32 user32 gnurx
 
 SRCS += directoryServer.cc
 SRCS += dirfmgr.cc


### PR DESCRIPTION
I've cross compiled this for Windows using Mingw64, I found I needed an additional library so that the regex symbols are resolved. I'm not sure if this project is using any of the GNU extensions to the regex library, if it's not I guess it should be `regex` instead of `gnurx` from my poor understanding of available regular expression libraries.