### PR TITLE
Add support for PCRE

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -16,28 +16,34 @@
 #   continue building even if conflicts are found.
 CHECK_RELEASE = YES
 
-# Set this when you only want to compile this application
-#   for a subset of the cross-compiled target architectures
-#   that Base is built for.
-#CROSS_COMPILER_TARGET_ARCHS = vxWorks-ppc32
-
 # To install files into a location other than $(TOP) define
 #   INSTALL_LOCATION here.
 #INSTALL_LOCATION=</absolute/path/to/install/top>
 
-# Set this when the IOC and build host use different paths
-#   to the install location. This may be needed to boot from
-#   a Microsoft FTP server say, or on some NFS configurations.
-#IOCS_APPL_TOP = </IOC's/absolute/path/to/install/top>
+# Set this to compile a self-contained executable
+#STATIC_BUILD = YES
 
-# For application debugging purposes, override the HOST_OPT and/
-#   or CROSS_OPT settings from base/configure/CONFIG_SITE
-#HOST_OPT = NO
-#CROSS_OPT = NO
+# Set one of these to use Perl Compatible Regular Expressions.
+#   Use this if libpcre is a system library (e.g. Linux)
+#SYS_PCRE = YES
+#   or these if it has been installed elsewhere
+#USE_PCRE = YES
+#PCRE = /path/to/pcre/installation
 
-# These allow developers to override the CONFIG_SITE variable
-# settings without having to modify the configure/CONFIG_SITE
-# file itself.
+# Path to the GNU Regex library, available from
+#   https://epics.anl.gov/extensions/gnuregex/index.php
+#   This isn't needed on Linux, or if PCRE (above) is configured
+#REGEX = /path/to/GNU/regex/installation
+
+# Set this to support DENY FROM <host ...> in the pvlist file.
+#   Alternative is to set EPICS_CAS_IGNORE_ADDR_LIST
+USE_DENYFROM = YES
+
+# Set this to support negative regex patterns in the pvlist file.
+#USE_NEG_REGEXP = YES
+
+# Allow developers to override the above CONFIG_SITE variables
+# without having to edit this file directly.
 -include $(TOP)/../CONFIG_SITE.local
 -include $(TOP)/configure/CONFIG_SITE.local
 

--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # Channel Access Name Server Release Notes
 
+## <date> - 2.1.0
+
+* Fixed use-after-free bug.
+* Removed obsolete `JS_FILEWAIT` and `PIOC` code.
+* Added support for Perl Compatible Regular Expressions from the
+ca-gateway module. Improved build configuration.
+
 ## Mon May 11 15:34:18 CST 2014 - 2.0.0.14
 
 * Changed asHost library name to dbCore for R3.15 base.

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,58 +1,45 @@
 TOP = ..
 include $(TOP)/configure/CONFIG
 
-#USR_CXXFLAGS += -DPIOC
-#USR_CXXFLAGS += -DJS_FILEWAIT
-USR_CXXFLAGS += -DUSE_DENYFROM
-#STATIC_BUILD=YES
-
-#ifeq ($(OS_CLASS),solaris)
-## Debugging options
-#DEBUGCMD = purify -first-only -chain-length=30  $($(ANSI)_$(CMPLR))
-#HOST_OPT=NO
-#endif
-
-# Purify
-#PURIFY=YES
-#ifeq ($(PURIFY),YES)
-#ifeq ($(OS_CLASS),solaris)
-#PURIFY_FLAGS = -first-only -chain-length=26 -max_threads=256
-## Put the cache files in the appropriate bin directory
-#PURIFY_FLAGS += -always-use-cache-dir -cache-dir=$(shell $(PERL) $(TOP)/config/fullPathName.pl .)
-#DEBUGCMD = purify $(PURIFY_FLAGS)
-#endif
-#endif
-
-# turns warnings into errors
-#USR_CXXFLAGS = +p
-
-# turns on all warnings
-#HOST_WARN=YES
-#CXXCMPLR = STRICT
-
-#CXXCMPLR = NORMAL
-#CCC_NORMAL = $(CCC)
-
-PROD_LIBS	+= cas
-
-ifdef BASE_3_15
-PROD_LIBS	+= dbCore
-else
-PROD_LIBS	+= asHost
+ifeq ($(USE_DENYFROM), YES)
+  USR_CXXFLAGS += -DUSE_DENYFROM
+endif
+ifeq ($(USE_NEG_REGEXP), YES)
+  USR_CXXFLAGS += -DUSE_NEG_REGEXP
 endif
 
-PROD_LIBS	+= ca
-PROD_LIBS	+= gdd
-PROD_LIBS	+= Com
+# Build with PCRE or Regex
+ifeq ($(SYS_PCRE), YES)
+  # Use system-supplied PCRE library
+  USR_CXXFLAGS += -DUSE_PCRE
+  PROD_SYS_LIBS += pcre
+else ifeq ($(USE_PCRE), YES)
+  # Use external PCRE library
+  USR_CXXFLAGS += -DUSE_PCRE
+  USR_INCLUDES += -I$(PCRE)/include
+  PROD_LIBS += pcre
+  pcre_DIR = $(firstword $(wildcard $(PCRE)/lib/$(T_A) $(PCRE)/lib))
+else ifneq ($(strip $(REGEX)),)
+  # Use external GNU Regex library
+  USR_INCLUDES += -I$(REGEX)/include
+  PROD_LIBS += regex
+  regex_DIR = $(firstword $(wildcard $(REGEX)/lib/$(T_A) $(REGEX)/lib))
+else ifneq ($(OS_CLASS), Linux)
+  # Must be a system-supplied GNU Regex library,
+  # except on Linux where it's part of libc
+  PROD_SYS_LIBS += regex
+endif
 
-cas_DIR  = $(EPICS_BASE_LIB)
-ca_DIR  = $(EPICS_BASE_LIB)
-asHost_DIR  = $(EPICS_BASE_LIB)
-Com_DIR = $(EPICS_BASE_LIB)
-gdd_DIR = $(EPICS_BASE_LIB)
+# From PCAS
+PROD_LIBS += cas gdd
 
-SYS_PROD_LIBS_solaris := nsl
-SYS_PROD_LIBS_WIN32 := ws2_32 advapi32 user32 gnurx
+ifdef EPICS_BASE_HOST_LIBS
+  PROD_LIBS += $(EPICS_BASE_HOST_LIBS)
+else
+  PROD_LIBS += dbCore ca Com
+endif
+
+PROD_SYS_LIBS_WIN32 = ws2_32 advapi32 user32
 
 SRCS += directoryServer.cc
 SRCS += dirfmgr.cc

--- a/src/gateAs.h
+++ b/src/gateAs.h
@@ -34,7 +34,6 @@
 #include "asLib.h"
 #include "errMdef.h"
 #include "gpHash.h"
-#include "asTrapWrite.h"
 
 #include "tsSLList.h"
 #include "tsHash.h"
@@ -139,14 +138,6 @@ public:
 	gateAsEntry* getEntry(void)
 	  { return asentry; }
 
-#ifdef SUPPORT_OWNER_CHANGE
-    // Used in virtual function setOwner from casChannel, not called
-    // from Gateway.  It is a security hole to support this, and it is
-    // no longer implemented in base.
-	long changeInfo(const char* user, const char* host)
-	  { return asChangeClient(asclientpvt,asentry->level,(char*)user,(char*)host);}
-#endif
-
 	const char *user(void) { return (const char*)asclientpvt->user; }
 	const char *host(void) { return (const char*)asclientpvt->host; }
 	ASCLIENTPVT clientPvt(void) { return asclientpvt; }
@@ -238,7 +229,7 @@ inline gateAsEntry* gateAs::findEntry(const char* pv, const char* host)
 	if(host && deny_from_table.find(host,pl)==0 &&	// DENY FROM
 	   findEntryInList(pv, *pl)) return NULL;
 
-	if(eval_order == GATE_ALLOW_FIRST &&			// DENY takes precedence
+	if(eval_order == GATE_ALLOW_FIRST &&		// DENY takes precedence
 	   findEntryInList(pv, deny_list)) return NULL;
 
 	return findEntryInList(pv, allow_list);
@@ -254,11 +245,3 @@ inline gateAsEntry* gateAs::findEntry(const char* pv)
 #endif
 
 #endif /* _GATEAS_H_ */
-
-/* **************************** Emacs Editing Sequences ***************** */
-/* Local Variables: */
-/* tab-width: 4 */
-/* c-basic-offset: 4 */
-/* c-comment-only-line-offset: 0 */
-/* c-file-offsets: ((substatement-open . 0) (label . 0)) */
-/* End: */


### PR DESCRIPTION
The PCRE code comes from the CA Gateway, which uses enhanced version of the same classes for doing the config file parsing and had PCRE added many years ago.

I have not tried building this on Windows, so it might break the PR #1 fix; any assistance to check that would be most welcome. I plan to release a new version of this module very soon.